### PR TITLE
fix: CobrowseView methods return elements not components

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,3 +18,5 @@ jobs:
       - run: npm ci
 
       - run: npm run lint
+
+      - run: npm run test:types

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "lint": "ts-standard",
     "lint:fix": "npm run lint -- --fix",
-    "start:dev": "nodemon --exec ./scripts/copy.sh"
+    "start:dev": "nodemon --exec ./scripts/copy.sh",
+    "test:types": "tsc -p tsconfig.eslint.json --noEmit"
   },
   "author": {
     "name": "Andy Pritchard"

--- a/ts/CobrowseView.d.ts
+++ b/ts/CobrowseView.d.ts
@@ -1,5 +1,5 @@
-import type { Component } from 'react'
-import type { View, Text } from 'react-native'
+import type { Component, ReactElement } from 'react'
+import type { ViewProps, TextProps } from 'react-native'
 
 export default class CobrowseView extends Component {
   componentDidMount (): Promise<void>
@@ -8,13 +8,13 @@ export default class CobrowseView extends Component {
 
   endSession (): Promise<void>
 
-  renderError (): Text
+  renderError (): ReactElement<TextProps>
 
-  renderCode (): View
+  renderCode (): ReactElement<ViewProps>
 
-  renderManageSession (): View
+  renderManageSession (): ReactElement<ViewProps>
 
-  renderContent (): Text | View
+  renderContent (): ReactElement<TextProps | ViewProps>
 
-  render (): View
+  render (): ReactElement<ViewProps>
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,13 +1,9 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
+    "lib": ["ES2015"],
     "strict": true,
-    "types": [
-      "react",
-      "react-native",
-      "jest"
-    ]
+    "types": ["react-native"]
   },
-  "include": [
-    "./ts/**/*.d.ts"
-  ]
+  "include": ["./ts/**/*.d.ts"]
 }


### PR DESCRIPTION
Stacked on [#28](https://github.com/cobrowseio/cobrowse-sdk-react-native/pull/28) ([Diff against #28](https://github.com/cobrowseio/cobrowse-sdk-react-native/compare/eps1lon:ci-types...eps1lon:fix/reactnode-types))

This was only possible before React 18 types since `ReactNode` used to contain `{}` i.e. any non-nullish value. 

With React 18 types we excluded `{}` so `CobrowseView` was no longer correctly typed. It seems to me, that it actually returns elements with the corresponding component props not the components themselves (at least from what I could gather from the `render` implementation).

It looks like the declaration files aren't verified at all. Running `yarn tsc -p tsconfig.eslint.json --noEmit` could not even start type-checking since Jest types were expected in the config but not installed. After removing jest from the config, `yarn tsc -p tsconfig.eslint.json --noEmit` revealed 62 type errors (mostly even more misconfiguration).