### PR TITLE
chore: Test types in CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,3 +18,5 @@ jobs:
       - run: npm ci
 
       - run: npm run lint
+
+      - run: npm run test:types

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "lint": "ts-standard",
     "lint:fix": "npm run lint -- --fix",
-    "start:dev": "nodemon --exec ./scripts/copy.sh"
+    "start:dev": "nodemon --exec ./scripts/copy.sh",
+    "test:types": "tsc -p tsconfig.eslint.json --noEmit"
   },
   "author": {
     "name": "Andy Pritchard"

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,13 +1,9 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
+    "lib": ["ES2015"],
     "strict": true,
-    "types": [
-      "react",
-      "react-native",
-      "jest"
-    ]
+    "types": ["react-native"]
   },
-  "include": [
-    "./ts/**/*.d.ts"
-  ]
+  "include": ["./ts/**/*.d.ts"]
 }


### PR DESCRIPTION
Reveals the type error fixed in https://github.com/cobrowseio/cobrowse-sdk-react-native/pull/27 by running `npm run test:types`. Added this task to CI to prevent further regression.

This required some changes to the tsconfig.eslint.json to make it runnable.