### PR TITLE
fix: update the version to one that exists

### DIFF
--- a/cobrowse-sdk-react-native.podspec
+++ b/cobrowse-sdk-react-native.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.homepage      = package["homepage"]
   s.source        = { :git => 'https://github.com/cobrowseio/cobrowse-sdk-react-native.git' }
   s.platform      = :ios, '11.0'
-  s.dependency      'CobrowseIO/XCFramework', '2.29.6'
+  s.dependency      'CobrowseIO/XCFramework', '2.28.6'
   s.dependency      'React'
   s.source_files =  'ios/*.{h,m}'
 end


### PR DESCRIPTION
I fixes the mismatch CobrowseIO version (`2.29.6`) to use the correct one (`2.28.6`). The version was updated in PR #45.