### PR TITLE
fix: update method for accessing UIManager for unredaction

### DIFF
--- a/android/src/main/java/io/cobrowse/reactnative/CobrowseIOCommonDelegates.java
+++ b/android/src/main/java/io/cobrowse/reactnative/CobrowseIOCommonDelegates.java
@@ -9,6 +9,5 @@ interface CobrowseIOCommonDelegates  extends CobrowseIO.Delegate, CobrowseIO.Ses
   CobrowseIO.SessionLoadDelegate, CobrowseIO.RedactionDelegate, CobrowseIO.UnredactionDelegate,
   CobrowseIO.RemoteControlRequestDelegate, CobrowseIO.FullDeviceRequestDelegate {
 
-  public void findNodeManager();
   public void setUnredactedTags(final ReadableArray reactTags, final Promise promise);
 }

--- a/android/src/main/java/io/cobrowse/reactnative/CobrowseIOModule.java
+++ b/android/src/main/java/io/cobrowse/reactnative/CobrowseIOModule.java
@@ -46,7 +46,6 @@ public class CobrowseIOModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void start() {
-    delegates.findNodeManager();
     final Activity activity = getReactApplicationContext().getCurrentActivity();
     if (activity != null)
       activity.runOnUiThread(new Runnable() {

--- a/js/Unredacted.tsx
+++ b/js/Unredacted.tsx
@@ -87,6 +87,10 @@ export function useUnredaction<C extends ComponentClass | ReactComponentType = V
   return setRef
 }
 
+function isViewComponent (Component: any): Component is typeof View {
+  return Component === View
+}
+
 export function unredact<T, P extends {}> (
   Component: RefHandlingComponent<T, P>
 ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> {
@@ -94,9 +98,10 @@ export function unredact<T, P extends {}> (
     function ComponentFromHOC (props, ref) {
       const localRef = useUnredaction(true, Component?.displayName) as ForwardedRef<T>
       const refs = useMemo(() => mergeRefs([localRef, ref]), [localRef, ref])
+      const componentProps = isViewComponent(Component) ? { ...props, collapsable: false } : props
 
       return (
-        <Component {...(props)} ref={refs} />
+        <Component {...(componentProps)} ref={refs} />
       )
     }
   )


### PR DESCRIPTION
Update method for accessing the `UIManager` when resolving unredacted views to support newer versions of React Native.

We also add the `collapsable` attribute with a value of `false` onto views which are being unredacted. This change ensures that views with no attributes are not removed by newer versions of React Native.