### PR TITLE
Update to sdk 3.9.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,7 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+' // support react-native-v0.22-rc+
-    implementation 'io.cobrowse:cobrowse-sdk-android:3.9.0'
+    implementation 'io.cobrowse:cobrowse-sdk-android:3.9.1'
     implementation 'androidx.webkit:webkit:1.4.0'
     implementation 'androidx.activity:activity:1.6.0'
 }


### PR DESCRIPTION
This is to update to use v3.9.1 of the android SDK which is yet to be released. 